### PR TITLE
fixes for django 2.0 + python 3+

### DIFF
--- a/simple_sso/sso_server/migrations/0001_initial.py
+++ b/simple_sso/sso_server/migrations/0001_initial.py
@@ -31,8 +31,8 @@ class Migration(migrations.Migration):
                 ('access_token', models.CharField(default=simple_sso.sso_server.models.TokenSecretKeyGenerator(b'access_token'), unique=True, max_length=64)),
                 ('timestamp', models.DateTimeField(default=timezone.now)),
                 ('redirect_to', models.CharField(max_length=255)),
-                ('consumer', models.ForeignKey(related_name='tokens', to='sso_server.Consumer')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True)),
+                ('consumer', models.ForeignKey(related_name='tokens', to='sso_server.Consumer', on_delete=models.DO_NOTHING)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True, on_delete=models.DO_NOTHING)),
             ],
         ),
     ]

--- a/simple_sso/sso_server/models.py
+++ b/simple_sso/sso_server/models.py
@@ -54,7 +54,7 @@ class Consumer(models.Model):
 
 
 class Token(models.Model):
-    consumer = models.ForeignKey(Consumer, related_name='tokens')
+    consumer = models.ForeignKey(Consumer, related_name='tokens', on_delete=models.DO_NOTHING)
     request_token = models.CharField(
         unique=True, max_length=64,
         default=TokenSecretKeyGenerator('request_token')
@@ -67,7 +67,8 @@ class Token(models.Model):
     redirect_to = models.CharField(max_length=255)
     user = models.ForeignKey(
         getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
-        null=True
+        null=True,
+        on_delete=models.DO_NOTHING
     )
 
     def refresh(self):

--- a/simple_sso/utils.py
+++ b/simple_sso/utils.py
@@ -4,7 +4,7 @@ from django.conf import settings
 import string
 random = SystemRandom()
 
-KEY_CHARACTERS = string.letters + string.digits
+KEY_CHARACTERS = string.ascii_letters + string.digits
 
 def default_gen_secret_key(length=40):
     return ''.join([random.choice(KEY_CHARACTERS) for _ in range(length)])


### PR DESCRIPTION
string.letters is removed from Python 3+, using string.ascii_letters
Also ForiegnKey requires on_delete constraint in Django 2+
